### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ fn main() {
 
     let mut buffer: RgbImage = ImageBuffer::new(IMAGE_WIDTH, IMAGE_HEIGHT);
 
-    for (x, z, y, pixel) in buffer.enumerate_pixels_mut(){
+    for (x, y, pixel) in buffer.enumerate_pixels_mut(){
         let r = x as f64 / (IMAGE_WIDTH-1) as f64;
         let g = y as f64 / (IMAGE_HEIGHT-1) as f64;
         let b = 0.25;


### PR DESCRIPTION
"Removed the unused 'z' element from the tuple to correct the error message indicating that the tuple contained 4 elements instead of the expected 3.